### PR TITLE
Fix incorrectly interpolated config setting

### DIFF
--- a/docs/nginx.md
+++ b/docs/nginx.md
@@ -112,7 +112,7 @@ server {
 
     ## If $docker_distribution_api_version is empty, the header will not be added.
     ## See the map directive above where this variable is defined.
-    add_header 'Docker-Distribution-Api-Version' $docker_distribution_api_version always;
+    add_header 'Docker-Distribution-Api-Version' \$docker_distribution_api_version always;
 
     proxy_pass                          http://docker-registry;
     proxy_set_header  Host              \$http_host;   # required for docker client's sake


### PR DESCRIPTION
Fixes a huge problem where a nginx variable was not escaped and nginx was adding the literal string "always" to all requests.
The most obvious result was that basic auth was entirely broken.

Signed-off-by: Carson Anderson ca@carson-anderson.com
